### PR TITLE
VS2013 Compilation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(pathtracer)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-narrowing -march=native -m64 -O3 -static -funroll-loops")
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-narrowing -march=native -m64 -O3 -static -funroll-loops")
+endif()
 
 FIND_PACKAGE( OpenMP REQUIRED)
 if(OPENMP_FOUND)

--- a/src/objects.h
+++ b/src/objects.h
@@ -23,7 +23,7 @@ class Object {
 
 public:
 	Vec m_p; // Position
-	virtual ObjectIntersection get_intersection(const Ray &r){};
+	virtual ObjectIntersection get_intersection(const Ray &r) = 0;
 };
 
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -23,7 +23,7 @@ void Renderer::render(int samples) {
 
     // Main Loop
     #pragma omp parallel for schedule(dynamic, 1)       // OpenMP
-    for (unsigned short y=0; y<height; y++){
+    for (int y=0; y<height; y++){
         unsigned short Xi[3]={0,0,y*y*y};               // Stores seed for erand48
 
         fprintf(stderr, "\rRendering (%i samples): %.2f%% ",      // Prints

--- a/src/texture.h
+++ b/src/texture.h
@@ -1,6 +1,6 @@
 #ifndef TEXTURE_H
 #define TEXTURE_H
-
+#include <vector>
 #include "vector.h"
 
 class Texture {

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,8 +1,8 @@
 #ifndef VECTOR_H
 #define VECTOR_H
-
 #include <algorithm>
 #include <math.h>
+#include <stdint.h>
 
 // Vector 3
 struct Vec {


### PR DESCRIPTION
- Make Object pure virtual
- Include stdint for uint32_t type
- Include vector for vector type
- Use "int" instead of "unsigned short" since MSVC requires OpenMP index
  variables be signed
